### PR TITLE
fixes TypeError on AdSpaceCoupon::getDescription()

### DIFF
--- a/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
+++ b/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
@@ -23,7 +23,7 @@ class AdSpaceCoupon
         return new Campaign($this->data['campaign']);
     }
 
-    public function getDescription(): string
+    public function getDescription(): ?string
     {
         return $this->data['description'];
     }


### PR DESCRIPTION
fixes TypeError on AdSpaceCoupon::getDescription(): `Return value must be of type string, null returned`