### PR TITLE
Draft: New dto and route structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0",
         "psr/http-client": "^1.0",
-        "php-http/discovery": "^1.19"
+        "php-http/discovery": "^1.19",
+        "nesbot/carbon": "^2.16"
     },
     "require-dev": {
         "symfony/http-client": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,184 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad9d349387540d3bfdc5fbf6d19583fd",
+    "content-hash": "763d04c0a3a0c3d9940d9ec558a6a855",
     "packages": [
+        {
+            "name": "carbonphp/carbon-doctrine-types",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/CarbonPHP/carbon-doctrine-types.git",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon-doctrine-types/zipball/18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "reference": "18ba5ddfec8976260ead6e866180bd5d2f71aa1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/dbal": "<4.0.0 || >=5.0.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^4.0.0",
+                "nesbot/carbon": "^2.71.0 || ^3.0.0",
+                "phpunit/phpunit": "^10.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\Doctrine\\": "src/Carbon/Doctrine/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "KyleKatarn",
+                    "email": "kylekatarnls@gmail.com"
+                }
+            ],
+            "description": "Types to use Carbon in Doctrine",
+            "keywords": [
+                "carbon",
+                "date",
+                "datetime",
+                "doctrine",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/CarbonPHP/carbon-doctrine-types/issues",
+                "source": "https://github.com/CarbonPHP/carbon-doctrine-types/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "2.72.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/briannesbitt/Carbon.git",
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/0c6fd108360c562f6e4fd1dedb8233b423e91c83",
+                "reference": "0c6fd108360c562f6e4fd1dedb8233b423e91c83",
+                "shasum": ""
+            },
+            "require": {
+                "carbonphp/carbon-doctrine-types": "*",
+                "ext-json": "*",
+                "php": "^7.1.8 || ^8.0",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.0 || ^3.1.4 || ^4.0",
+                "doctrine/orm": "^2.7 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "kylekatarnls/multi-tester": "^2.0",
+                "ondrejmirtes/better-reflection": "*",
+                "phpmd/phpmd": "^2.9",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.99 || ^1.7.14",
+                "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
+                "squizlabs/php_codesniffer": "^3.4"
+            },
+            "bin": [
+                "bin/carbon"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "2.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Carbon\\Laravel\\ServiceProvider"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "https://markido.com"
+                },
+                {
+                    "name": "kylekatarnls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "An API extension for DateTime that supports 281 different languages.",
+            "homepage": "https://carbon.nesbot.com",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "support": {
+                "docs": "https://carbon.nesbot.com/docs",
+                "issues": "https://github.com/briannesbitt/Carbon/issues",
+                "source": "https://github.com/briannesbitt/Carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-25T10:35:09+00:00"
+        },
         {
             "name": "php-http/discovery",
             "version": "1.19.4",
@@ -84,6 +260,54 @@
                 "source": "https://github.com/php-http/discovery/tree/1.19.4"
             },
             "time": "2024-03-29T13:00:05+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/http-client",
@@ -189,6 +413,406 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v6.4.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "7495687c58bfd88b7883823747b0656d90679123"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7495687c58bfd88b7883823747b0656d90679123",
+                "reference": "7495687c58bfd88b7883823747b0656d90679123",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5|^3.0"
+            },
+            "conflict": {
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "symfony/translation-implementation": "2.3|3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.18|^5.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^5.4|^6.0|^7.0",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/finder": "^5.4|^6.0|^7.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^5.4|^6.0|^7.0",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/routing": "^5.4|^6.0|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to internationalize your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v6.4.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:22:46+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
+                "reference": "b9d2189887bb6b2e0367a9fc7136c5239ab9b05a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
         }
     ],
     "packages-dev": [
@@ -1203,16 +1827,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.17",
+            "version": "10.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c1f736a473d21957ead7e94fcc029f571895abf5"
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c1f736a473d21957ead7e94fcc029f571895abf5",
-                "reference": "c1f736a473d21957ead7e94fcc029f571895abf5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/547d314dc24ec1e177720d45c6263fb226cc2ae3",
+                "reference": "547d314dc24ec1e177720d45c6263fb226cc2ae3",
                 "shasum": ""
             },
             "require": {
@@ -1284,7 +1908,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.20"
             },
             "funding": [
                 {
@@ -1300,7 +1924,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:39:01+00:00"
+            "time": "2024-04-24T06:32:35+00:00"
         },
         {
             "name": "psr/container",
@@ -1357,20 +1981,20 @@
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
@@ -1394,7 +2018,7 @@
                     "homepage": "https://www.php-fig.org/"
                 }
             ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
             "keywords": [
                 "factory",
                 "http",
@@ -1406,9 +2030,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+                "source": "https://github.com/php-fig/http-factory"
             },
-            "time": "2023-04-10T20:10:41+00:00"
+            "time": "2024-04-15T12:06:14+00:00"
         },
         {
             "name": "psr/log",
@@ -2377,84 +3001,17 @@
             "time": "2023-02-07T11:34:05+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.4-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
             "name": "symfony/http-client",
-            "version": "v7.0.6",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "6e70473909f46fe5dd3b994a0f1b20ecb6b2f858"
+                "reference": "6ce3c4c899051b3d7326ea1a1dda3729e29ae6d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/6e70473909f46fe5dd3b994a0f1b20ecb6b2f858",
-                "reference": "6e70473909f46fe5dd3b994a0f1b20ecb6b2f858",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/6ce3c4c899051b3d7326ea1a1dda3729e29ae6d7",
+                "reference": "6ce3c4c899051b3d7326ea1a1dda3729e29ae6d7",
                 "shasum": ""
             },
             "require": {
@@ -2517,7 +3074,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.0.6"
+                "source": "https://github.com/symfony/http-client/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -2533,20 +3090,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-01T20:49:44+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.4.2",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "b6b5c876b3a4ed74460e2c5ac53bbce2f12e2a7e"
+                "reference": "20414d96f391677bf80078aa55baece78b82647d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/b6b5c876b3a4ed74460e2c5ac53bbce2f12e2a7e",
-                "reference": "b6b5c876b3a4ed74460e2c5ac53bbce2f12e2a7e",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/20414d96f391677bf80078aa55baece78b82647d",
+                "reference": "20414d96f391677bf80078aa55baece78b82647d",
                 "shasum": ""
             },
             "require": {
@@ -2555,7 +3112,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2595,7 +3152,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.4.2"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -2611,20 +3168,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-01T18:51:09+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.0.0",
+            "version": "v7.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "700ff4096e346f54cb628ea650767c8130f1001f"
+                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/700ff4096e346f54cb628ea650767c8130f1001f",
-                "reference": "700ff4096e346f54cb628ea650767c8130f1001f",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/23cc173858776ad451e31f053b1c9f47840b2cfa",
+                "reference": "23cc173858776ad451e31f053b1c9f47840b2cfa",
                 "shasum": ""
             },
             "require": {
@@ -2662,7 +3219,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.0.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.0.7"
             },
             "funding": [
                 {
@@ -2678,105 +3235,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-08T10:20:21+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-04-18T09:29:19+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.4.2",
+            "version": "v3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "11bbf19a0fb7b36345861e85c5768844c552906e"
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/11bbf19a0fb7b36345861e85c5768844c552906e",
-                "reference": "11bbf19a0fb7b36345861e85c5768844c552906e",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "psr/container": "^1.1|^2.0"
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2"
@@ -2784,7 +3262,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.4-dev"
+                    "dev-main": "3.5-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -2824,7 +3302,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.4.2"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
             },
             "funding": [
                 {
@@ -2840,7 +3318,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-19T21:51:00+00:00"
+            "time": "2024-04-18T09:32:20+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2899,7 +3377,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/src/Api/Endpoints/Coupons/V2/Campaign.php
+++ b/src/Api/Endpoints/Coupons/V2/Campaign.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2;
+
+class Campaign
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $siteUrl,
+    ){}
+}

--- a/src/Api/Endpoints/Coupons/V2/CouponCategory.php
+++ b/src/Api/Endpoints/Coupons/V2/CouponCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2;
+
+class CouponCategory
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ){}
+}

--- a/src/Api/Endpoints/Coupons/V2/CouponType.php
+++ b/src/Api/Endpoints/Coupons/V2/CouponType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2;
+
+class CouponType
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ){}
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/Coupon.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/Coupon.php
@@ -9,68 +9,27 @@ use Carbon\Carbon;
 
 class Coupon
 {
-    public string   $status;
-    public float    $rating;
-    public Campaign $campaign;
-    public ?string  $description;
-    public string   $shortName;
-    public bool     $isExclusive;
-    public Carbon   $dateStart;
-    public ?Carbon  $dateEnd;
-    public int      $id;
-    public array    $regions;
-    public ?string  $discount;
-    /** @var array<CouponType> $types */
-    public array    $types;
-    public string   $image;
-    public string   $species;
-    /** @var array<CouponCategory> $categories */
-    public array    $categories;
-    public string   $name;
-    public string   $language;
-    public bool     $isUnique;
-    public bool     $isPersonal;
-
     public function __construct(
-        string  $status,
-        float   $rating,
-        array   $campaignData,
-        ?string $description,
-        string  $shortName,
-        bool    $isExclusive,
-        string  $dateStart,
-        ?string $dateEnd,
-        int     $id,
-        array   $regions,
-        ?string $discount,
-        array   $types,
-        string  $image,
-        string  $species,
-        array   $categories,
-        string  $name,
-        string  $language,
-        bool    $isUnique,
-        bool    $isPersonal,
-    )
-    {
-        $this->status = $status;
-        $this->rating = $rating;
-        $this->campaign = new Campaign($campaignData['id'], $campaignData['name'], $campaignData['site_url']);
-        $this->description = $description;
-        $this->shortName = $shortName;
-        $this->isExclusive = $isExclusive;
-        $this->dateStart = Carbon::parse($dateStart);
-        $this->dateEnd = $dateEnd ? Carbon::parse($dateEnd) : null;
-        $this->id = $id;
-        $this->regions = $regions;
-        $this->discount = $discount;
-        $this->types = array_map(fn (array $item) => new CouponType($item['id'], $item['name']), $types);
-        $this->image = $image;
-        $this->species = $species;
-        $this->categories = array_map(fn (array $item) => new CouponCategory($item['id'], $item['name']), $categories);
-        $this->name = $name;
-        $this->language = $language;
-        $this->isUnique = $isUnique;
-        $this->isPersonal = $isPersonal;
-    }
+        public string   $status,
+        public float    $rating,
+        public Campaign $campaign,
+        public ?string  $description,
+        public string   $shortName,
+        public bool     $isExclusive,
+        public Carbon   $dateStart,
+        public ?Carbon  $dateEnd,
+        public int      $id,
+        public array    $regions,
+        public ?string  $discount,
+        /** @var array<CouponType> $types */
+        public array    $types,
+        public string   $image,
+        public string   $species,
+        /** @var array<CouponCategory> $categories */
+        public array    $categories,
+        public string   $name,
+        public string   $language,
+        public bool     $isUnique,
+        public bool     $isPersonal,
+    ){}
 }

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/Coupon.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/Coupon.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\Campaign;
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\CouponCategory;
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\CouponType;
+use Carbon\Carbon;
+
+class Coupon
+{
+    public string   $status;
+    public float    $rating;
+    public Campaign $campaign;
+    public ?string  $description;
+    public string   $shortName;
+    public bool     $isExclusive;
+    public Carbon   $dateStart;
+    public ?Carbon  $dateEnd;
+    public int      $id;
+    public array    $regions;
+    public ?string  $discount;
+    /** @var array<CouponType> $types */
+    public array    $types;
+    public string   $image;
+    public string   $species;
+    /** @var array<CouponCategory> $categories */
+    public array    $categories;
+    public string   $name;
+    public string   $language;
+    public bool     $isUnique;
+    public bool     $isPersonal;
+
+    public function __construct(
+        string  $status,
+        float   $rating,
+        array   $campaignData,
+        ?string $description,
+        string  $shortName,
+        bool    $isExclusive,
+        string  $dateStart,
+        ?string $dateEnd,
+        int     $id,
+        array   $regions,
+        ?string $discount,
+        array   $types,
+        string  $image,
+        string  $species,
+        array   $categories,
+        string  $name,
+        string  $language,
+        bool    $isUnique,
+        bool    $isPersonal,
+    )
+    {
+        $this->status = $status;
+        $this->rating = $rating;
+        $this->campaign = new Campaign($campaignData['id'], $campaignData['name'], $campaignData['site_url']);
+        $this->description = $description;
+        $this->shortName = $shortName;
+        $this->isExclusive = $isExclusive;
+        $this->dateStart = Carbon::parse($dateStart);
+        $this->dateEnd = $dateEnd ? Carbon::parse($dateEnd) : null;
+        $this->id = $id;
+        $this->regions = $regions;
+        $this->discount = $discount;
+        $this->types = array_map(fn (array $item) => new CouponType($item['id'], $item['name']), $types);
+        $this->image = $image;
+        $this->species = $species;
+        $this->categories = array_map(fn (array $item) => new CouponCategory($item['id'], $item['name']), $categories);
+        $this->name = $name;
+        $this->language = $language;
+        $this->isUnique = $isUnique;
+        $this->isPersonal = $isPersonal;
+    }
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/CouponDTOFactory.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/CouponDTOFactory.php
@@ -2,26 +2,37 @@
 
 namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
 
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\Campaign;
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\CouponCategory;
+use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\CouponType;
+use Carbon\Carbon;
+
 class CouponDTOFactory
 {
     public static function createCoupon(array $data): Coupon
     {
+        $campaign = new Campaign($data['campaign']['id'], $data['campaign']['name'], $data['campaign']['site_url']);
+        $dateStart = Carbon::parse($data['date_start']);
+        $dateEnd = !empty($data['date_end']) ? Carbon::parse($data['date_end']) : null;
+        $couponTypes = array_map(fn (array $item) => new CouponType($item['id'], $item['name']), $data['types']);
+        $couponCategories = array_map(fn (array $item) => new CouponCategory($item['id'], $item['name']), $data['categories']);
+
         return new Coupon(
             $data['status'],
             $data['rating'],
-            $data['campaign'],
+            $campaign,
             $data['description'],
             $data['short_name'],
             $data['exclusive'],
-            $data['date_start'],
-            $data['date_end'],
+            $dateStart,
+            $dateEnd,
             $data['id'],
             $data['regions'],
             $data['discount'],
-            $data['types'],
+            $couponTypes,
             $data['image'],
             $data['species'],
-            $data['categories'],
+            $couponCategories,
             $data['name'],
             $data['language'],
             $data['is_unique'],

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/CouponDTOFactory.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/CouponDTOFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+class CouponDTOFactory
+{
+    public static function createCoupon(array $data): Coupon
+    {
+        return new Coupon(
+            $data['status'],
+            $data['rating'],
+            $data['campaign'],
+            $data['description'],
+            $data['short_name'],
+            $data['exclusive'],
+            $data['date_start'],
+            $data['date_end'],
+            $data['id'],
+            $data['regions'],
+            $data['discount'],
+            $data['types'],
+            $data['image'],
+            $data['species'],
+            $data['categories'],
+            $data['name'],
+            $data['language'],
+            $data['is_unique'],
+            $data['is_personal'],
+        );
+    }
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetListOfCoupons.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetListOfCoupons.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+use Affiliateforge\PhpAdmitadApi\Api\CommandDTO;
+use Affiliateforge\PhpAdmitadApi\Api\ResponseDTO;
+use Affiliateforge\PhpAdmitadApi\Api\Traits\HttpMethods\GET;
+use Carbon\Carbon;
+use Psr\Http\Message\ResponseInterface;
+
+class GetListOfCoupons extends CommandDTO
+{
+    use GET;
+
+    public function __construct(
+        private ?int $campaign = null,
+        private ?int $category = null,
+        private ?int $campaignCategory = null,
+        private ?int $type = null,
+        private ?string $search = null,
+        private ?Carbon $dateStart = null,
+        private ?Carbon $dateEnd = null,
+        private ?int $offset = null,
+        private ?int $limit = null,
+        private ?string $orderBy = null,
+        private ?string $region = null,
+        private ?string $language = null,
+    ){}
+
+    public function getUrlPath(): string
+    {
+        return '/coupons/';
+    }
+
+    public function getQueryParams(): array
+    {
+        $params = [
+            'campaign' => $this->campaign,
+            'category' => $this->category,
+            'campaignCategory' => $this->campaignCategory,
+            'type' => $this->type,
+            'search' => $this->search,
+            'date_start' => $this->dateStart?->format('d.m.Y'),
+            'date_end' => $this->dateEnd?->format('d.m.Y'),
+            'offset' => $this->offset,
+            'limit' => $this->limit,
+            'order_by' => $this->orderBy,
+            'region' => $this->region,
+            'language' => $this->language,
+        ];
+
+        return array_filter($params);
+    }
+
+    public function makeResponseDTO(ResponseInterface $response): ResponseDTO
+    {
+        return new GetListOfCouponsResponse($response);
+    }
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetListOfCouponsResponse.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetListOfCouponsResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+use Affiliateforge\PhpAdmitadApi\Api\ResponseDTO;
+use Affiliateforge\PhpAdmitadApi\Api\Traits\HasMetaInResponse;
+
+class GetListOfCouponsResponse extends ResponseDTO
+{
+    use HasMetaInResponse;
+
+    /**
+     * @return array<Coupon>
+     */
+    public function getResults(): array
+    {
+        return array_map(
+            fn (array $item) => CouponDTOFactory::createCoupon($item),
+            $this->getParsedBody()['results']
+        );
+    }
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetSingleCoupon.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetSingleCoupon.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+use Affiliateforge\PhpAdmitadApi\Api\CommandDTO;
+use Affiliateforge\PhpAdmitadApi\Api\ResponseDTO;
+use Affiliateforge\PhpAdmitadApi\Api\Traits\HttpMethods\GET;
+use Psr\Http\Message\ResponseInterface;
+
+class GetSingleCoupon extends CommandDTO
+{
+    use GET;
+
+    public function __construct(
+        private int $id
+    ){}
+
+    public function getUrlPath(): string
+    {
+        return "/coupons/$this->id/";
+    }
+
+    public function makeResponseDTO(ResponseInterface $response): ResponseDTO
+    {
+        return new GetSingleCouponResponse($response);
+    }
+}

--- a/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetSingleCouponResponse.php
+++ b/src/Api/Endpoints/Coupons/V2/ListOfCoupons/GetSingleCouponResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons;
+
+use Affiliateforge\PhpAdmitadApi\Api\ResponseDTO;
+
+class GetSingleCouponResponse extends ResponseDTO
+{
+    public function getCoupon(): Coupon
+    {
+        return CouponDTOFactory::createCoupon($this->getParsedBody());
+    }
+}


### PR DESCRIPTION
Изменения:

1. **Поля ДТО в конструкторе, а не через геттеры.**
Раньше ДТО, которые описывают возвращаемые из API сущности,принимали в конструкторе массив и дальше через геттеры мы парсили этот массив и возращали поля. Теперь эти ДТО принимают сразу все необходимые поля в конструкторе. Это повышает понимание, что будет содержать это ДТО. Для создания этих ДТО мы используем отдельный класс Factory. 

2. **Откатили минимально необходимую версию PHP до 8.0.** 
Вследствие этого, в конструкторах нельзя указывать свойства readonly.

3. **Для дат теперь используем Carbon**

4. **Дробим namespac'ы внутри группы endpoint'ов**
Теперь каждую группу ендпонитов мы кладем в отдельный namespace. Раньше в одной папке были вообще все запросы, относящиеся к функциональности API (одна страница в документации Admitad). Т.е раньше, например, в одном namespace лежали вообще все запросы и ответы для [Купонов](https://developers.admitad.com/hc/en-us/articles/7930482029585-Coupons) и их namespace был просто `Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons`. Теперь, помимо этого базового namespace, мы также добавляем внутри еще один - на группу запросов, которые описываются в документации одним пунктом. В данном случае - на [List of coupons ](https://developers.admitad.com/hc/en-us/articles/7930482029585-Coupons#list-of-coupons). Выходит полный namespace: `Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons`. Соответственно, для List of [coupons for the ad space](https://developers.admitad.com/hc/en-us/articles/7930482029585-Coupons#list-of-coupons-for-the-ad-space) namespace будет `Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\AdSpaceCoupons`. Раньше эти запросы лежали там же, что и обычные купоны (`Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons`). Т.е. мы дробим на более мелкие namespac'ы.
ДТО, которые будут общими для нескольких групп запросов - храним в общем namespac'e. Для ДТО, которые специфичный для одной конкретной группы запросов - внутри namespac'a этой группы. Примеры:
- `Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\ListOfCoupons\Coupon` - специфичен только для группы и лежит внутри ее namespac'a.
- `Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\V2\Campaign` - будет общим как для списка купонов, так и для списка купонов для рекламной площадки. Поэтому храним выше.