### PR TITLE
Fixes date creation when AdSpaceCoupon getDateEnd is null

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+#!/usr/bin/env make
+# SHELL = sh -xv
+
+WORKING_DIR := /chamber
+DOCKER_RUN := docker run -w ${WORKING_DIR} -v "$(shell pwd):${WORKING_DIR}"
+
+.PHONY: help
+help:  ## Shows this help message
+	@echo "\n  Usage: make [target]\n\n  Targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' "$(shell pwd)/Makefile" | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "    🔸 \033[36m%-30s\033[0m %s\n\n", $$1, $$2}'
+
+.PHONY: composer-install
+composer-install:
+	${DOCKER_RUN} composer:2 composer install
+
+.PHONY: test
+test:
+	${DOCKER_RUN} php:8.1-cli vendor/bin/phpunit

--- a/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
+++ b/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
@@ -2,6 +2,8 @@
 
 namespace Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\Entities;
 
+use Exception;
+
 class AdSpaceCoupon
 {
     public function __construct(
@@ -38,14 +40,20 @@ class AdSpaceCoupon
         return $this->data['exclusive'];
     }
 
+    /**
+     * @throws Exception
+     */
     public function getDateStart(): \DateTime
     {
         return new \DateTime($this->data['date_start']);
     }
 
+    /**
+     * @throws Exception
+     */
     public function getDateEnd(): ?\DateTime
     {
-        return isset($this->data['date_end']) ? new \DateTime($this->data['date_end']) : null;
+        return is_null($this->data['date_end']) ? null : new \DateTime($this->data['date_end']);
     }
 
     public function getId(): int

--- a/tests/Unit/Api/Endpoints/Coupons/Entities/AdSpaceCouponTest.php
+++ b/tests/Unit/Api/Endpoints/Coupons/Entities/AdSpaceCouponTest.php
@@ -6,53 +6,82 @@ use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\Entities\AdSpaceCoupon;
 use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\Entities\Campaign;
 use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\Entities\Category;
 use Affiliateforge\PhpAdmitadApi\Api\Endpoints\Coupons\Entities\Type;
+use Exception;
+use Generator;
 use PHPUnit\Framework\TestCase;
 
 class AdSpaceCouponTest extends TestCase
 {
-    public function testGetters()
+    /**
+     * @return void
+     * @dataProvider gettersDataProvider
+     * @throws Exception
+     */
+    public function testGetters(array $coupon)
     {
-        $singleCouponResponseJson = <<<JSON
-{"status":"active","rating":"4.82","campaign":{"id":777,"name":"Name","site_url":"https://www.example.com/"},"description":"","short_name":"Short name","exclusive":false,"date_end":"2024-05-31T23:59:00","date_start":"2024-03-01T00:00:00","id":3,"regions":["RU"],"discount":"500 ₽","types":[{"id":2,"name":"Full name"}],"image":"http://cdn.admitad.com/campaign/images/2021/4/5/tratata.svg","species":"promocode","categories":[{"id":1,"name":"Toys, Kids & Babies"}],"name":"Name","language":"ru","is_unique":false,"is_personal":false,"promocode":"promocode","frameset_link":"https://example.com/coupon/jgmk2fspjv767c32d944748f778371/?erid=adF","goto_link":"https://example.com/g/asd/?i=3&erid=adF"}
-JSON;
+        $dto = new AdSpaceCoupon($coupon);
 
-        $dto = new AdSpaceCoupon(json_decode($singleCouponResponseJson, true));
+        $this->assertSame($coupon['status'], $dto->getStatus());
+        $this->assertSame((float)$coupon['rating'], $dto->getRating());
+        $this->assertSame($coupon['description'], $dto->getDescription());
+        $this->assertSame($coupon['short_name'], $dto->getShortName());
 
-        $this->assertSame('active', $dto->getStatus());
-        $this->assertSame(4.82, $dto->getRating());
-        $this->assertSame('', $dto->getDescription());
-        $this->assertSame('Short name', $dto->getShortName());
-        $this->assertFalse($dto->isExclusive());
-        $this->assertEquals(new \DateTime('2024-05-31T23:59:00'), $dto->getDateEnd());
-        $this->assertEquals(new \DateTime('2024-03-01T00:00:00'), $dto->getDateStart());
-        $this->assertSame(3, $dto->getId());
-        $this->assertEquals(['RU'], $dto->getRegions());
-        $this->assertSame('500 ₽', $dto->getDiscount());
-        $this->assertSame('http://cdn.admitad.com/campaign/images/2021/4/5/tratata.svg', $dto->getImage());
-        $this->assertSame('promocode', $dto->getSpecies());
-        $this->assertSame('Name', $dto->getName());
-        $this->assertSame('ru', $dto->getLanguage());
-        $this->assertFalse($dto->isUnique());
-        $this->assertFalse($dto->isPersonal());
-        $this->assertSame('https://example.com/coupon/jgmk2fspjv767c32d944748f778371/?erid=adF', $dto->getFramesetLink());
-        $this->assertSame('https://example.com/g/asd/?i=3&erid=adF', $dto->getGotoLink());
-        $this->assertSame('promocode', $dto->getPromocode());
+        $this->assertIsBool($dto->isExclusive());
+        $this->assertSame($coupon['exclusive'], $dto->isExclusive());
+
+        if (is_null($coupon['date_end'])) {
+            $this->assertNull($dto->getDateEnd());
+        } else {
+            $this->assertEquals(new \DateTime($coupon['date_end']), $dto->getDateEnd());
+        }
+
+        $this->assertEquals(new \DateTime($coupon['date_start']), $dto->getDateStart());
+        $this->assertSame($coupon['id'], $dto->getId());
+        $this->assertEquals($coupon['regions'], $dto->getRegions());
+        $this->assertSame($coupon['discount'], $dto->getDiscount());
+        $this->assertSame($coupon['image'], $dto->getImage());
+        $this->assertSame($coupon['species'], $dto->getSpecies());
+        $this->assertSame($coupon['name'], $dto->getName());
+        $this->assertSame($coupon['language'], $dto->getLanguage());
+
+        $this->assertIsBool($dto->isUnique());
+        $this->assertSame($coupon['is_unique'], $dto->isUnique());
+
+        $this->assertIsBool($dto->isPersonal());
+        $this->assertSame($coupon['frameset_link'], $dto->getFramesetLink());
+        $this->assertSame($coupon['goto_link'], $dto->getGotoLink());
+        $this->assertSame($coupon['promocode'], $dto->getPromocode());
 
         $this->assertInstanceOf(Campaign::class, $dto->getCampaign());
-        $this->assertSame(777, $dto->getCampaign()->getId());
-        $this->assertSame('Name', $dto->getCampaign()->getName());
-        $this->assertSame('https://www.example.com/', $dto->getCampaign()->getSiteUrl());
+        $this->assertSame($coupon['campaign']['id'], $dto->getCampaign()->getId());
+        $this->assertSame($coupon['campaign']['name'], $dto->getCampaign()->getName());
+        $this->assertSame($coupon['campaign']['site_url'], $dto->getCampaign()->getSiteUrl());
 
         $this->assertIsArray($dto->getTypes());
-        $this->assertCount(1, $dto->getTypes());
-        $this->assertInstanceOf(Type::class, $dto->getTypes()[0]);
-        $this->assertSame(2, $dto->getTypes()[0]->getId());
-        $this->assertSame('Full name', $dto->getTypes()[0]->getName());
+        $this->assertCount(count($coupon['types']), $dto->getTypes());
+        foreach ($dto->getTypes() as $i => $type) {
+            $this->assertInstanceOf(Type::class, $type);
+            $this->assertSame($coupon['types'][$i]['id'], $type->getId());
+            $this->assertSame($coupon['types'][$i]['name'], $type->getName());
+        }
 
         $this->assertIsArray($dto->getCategories());
-        $this->assertCount(1, $dto->getCategories());
-        $this->assertInstanceOf(Category::class, $dto->getCategories()[0]);
-        $this->assertSame(1, $dto->getCategories()[0]->getId());
-        $this->assertSame('Toys, Kids & Babies', $dto->getCategories()[0]->getName());
+        $this->assertCount(count($coupon['categories']), $dto->getCategories());
+        foreach ($dto->getCategories() as $i => $category) {
+            $this->assertInstanceOf(Category::class, $category);
+            $this->assertSame($coupon['categories'][$i]['id'], $category->getId());
+            $this->assertSame($coupon['categories'][$i]['name'], $category->getName());
+        }
+    }
+
+
+    static function gettersDataProvider(): Generator
+    {
+        foreach (json_decode(
+            file_get_contents(__DIR__ . '/fixtures/adspace-coupons.json'),
+            true
+        ) as $coupon) {
+            yield [ $coupon ];
+        }
     }
 }

--- a/tests/Unit/Api/Endpoints/Coupons/Entities/fixtures/adspace-coupons.json
+++ b/tests/Unit/Api/Endpoints/Coupons/Entities/fixtures/adspace-coupons.json
@@ -1,0 +1,113 @@
+[
+  {
+    "status": "active",
+    "rating": "4.82",
+    "campaign": {
+      "id":777,
+      "name":"Name",
+      "site_url":"https://www.example.com/"
+    },
+    "description":"",
+    "short_name":"Short name",
+    "exclusive":false,
+    "date_end":"2024-05-31T23:59:00",
+    "date_start":"2024-03-01T00:00:00",
+    "id":3,
+    "regions":
+      [
+        "RU"
+      ],
+    "discount":"500 ₽",
+    "types":
+    [
+      {
+        "id":2,
+        "name":"Full name"
+      }
+    ],
+    "image":"http://cdn.admitad.com/campaign/images/2021/4/5/tratata.svg",
+    "species":"promocode",
+    "categories":
+    [
+      {
+        "id":1,
+        "name":"Toys, Kids & Babies"
+      }
+    ],
+    "name":"Name",
+    "language":"ru",
+    "is_unique":false,
+    "is_personal":false,
+    "promocode":"promocode",
+    "frameset_link":"https://example.com/coupon/jgmk2fspjv767c32d944748f778371/?erid=adF",
+    "goto_link":"https://example.com/g/asd/?i=3&erid=adF"
+  },
+  {
+    "status": "active",
+    "rating": "0.00",
+    "campaign": {
+      "id": 37409,
+      "name": "Temu Many Geos",
+      "site_url": "https://temu.com/"
+    },
+    "description": "*The code is only valid with this specific link! - Limit one Offer per user for one order.",
+    "short_name": "CA ADMITAD Exclusive: 30% off for orders $39+, capped at $25. New User Only!",
+    "exclusive": true,
+    "date_end": null,
+    "date_start": "2024-04-18T07:29:12",
+    "id": 748737,
+    "regions": [
+      "CA"
+    ],
+    "discount": "30%",
+    "types": [
+      {
+        "id": 2,
+        "name": "Order discount"
+      }
+    ],
+    "image": "http://cdn.admitad.com/campaign/images/2023/5/18/37409-a2f8f0c50dc7fa13.svg",
+    "species": "promocode",
+    "categories": [
+      {
+        "id": 1,
+        "name": "Toys, Kids & Babies"
+      },
+      {
+        "id": 3,
+        "name": "Accessories & Bags"
+      },
+      {
+        "id": 4,
+        "name": "Shoes"
+      },
+      {
+        "id": 5,
+        "name": "Clothing"
+      },
+      {
+        "id": 7,
+        "name": "Homeware"
+      },
+      {
+        "id": 8,
+        "name": "Computers & Electronics"
+      },
+      {
+        "id": 24,
+        "name": "Outdoor Clothing & Equipment"
+      },
+      {
+        "id": 34,
+        "name": "Marketplaces (including Chinese Stores)"
+      }
+    ],
+    "name": "CA ADMITAD Exclusive: 30% off for orders $39+, capped at $25. New User Only!",
+    "language": "en",
+    "is_unique": false,
+    "is_personal": false,
+    "promocode": "ADMITADCA30",
+    "frameset_link": "",
+    "goto_link": "https://zejcl.com/g/mmkzo5nv19083e13e4121a1fb2e417/?i=3"
+  }
+]


### PR DESCRIPTION
Fixing issue when AdSpaceCoupon's `end_date` is `null` then DTO creates \DateTime with current date and time.
