### PR TITLE
fix(coupons): handle nullable promocode in `AdSpaceCoupon`

### DIFF
--- a/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
+++ b/src/Api/Endpoints/Coupons/Entities/AdSpaceCoupon.php
@@ -133,7 +133,7 @@ class AdSpaceCoupon
         return $this->data['goto_link'];
     }
 
-    public function getPromocode(): string
+    public function getPromocode(): ?string
     {
         return $this->data['promocode'];
     }


### PR DESCRIPTION
- Change `getPromocode` return type from `string` to `?string`
- Allow for nullable promocodes in `AdSpaceCoupon` entity
- Ensure compatibility with data that may not always include a `promocode`