### PR TITLE
test(GetAdSpaceCouponsListTest): update `category` to array

### DIFF
--- a/tests/Unit/Api/Endpoints/Coupons/GetAdSpaceCouponsListTest.php
+++ b/tests/Unit/Api/Endpoints/Coupons/GetAdSpaceCouponsListTest.php
@@ -14,7 +14,7 @@ class GetAdSpaceCouponsListTest extends TestCase
         $dto = new GetAdSpaceCouponsList(
             3,
             campaign: 3,
-            category: 1,
+            category: [1],
             campaignCategory: 89,
             type: 14,
             search: 'search-string',
@@ -32,7 +32,7 @@ class GetAdSpaceCouponsListTest extends TestCase
         $this->assertEmpty($dto->getBody());
         $this->assertSame([
             'campaign' => 3,
-            'category' => 1,
+            'category' => [1],
             'campaignCategory' => 89,
             'type' => 14,
             'search' => 'search-string',


### PR DESCRIPTION
- Change `category` parameter from `int` to `array` in `GetAdSpaceCouponsList` constructor
- Update related test assertions to reflect the new `category` array format