### PR TITLE
fix(coupons): correct data types for `campaign` parameter

### DIFF
--- a/src/Api/Endpoints/Coupons/GetAdSpaceCouponsList.php
+++ b/src/Api/Endpoints/Coupons/GetAdSpaceCouponsList.php
@@ -13,8 +13,8 @@ class GetAdSpaceCouponsList extends CommandDTO
 
     public function __construct(
         private readonly int $spaceID,
-        private readonly ?int $campaign = null,
-        private readonly ?array $category = null,
+        private readonly ?array $campaign = null,
+        private readonly ?int $category = null,
         private readonly ?int $campaignCategory = null,
         private readonly ?int $type = null,
         private readonly ?string $search = null,

--- a/tests/Unit/Api/Endpoints/Coupons/GetAdSpaceCouponsListTest.php
+++ b/tests/Unit/Api/Endpoints/Coupons/GetAdSpaceCouponsListTest.php
@@ -13,8 +13,8 @@ class GetAdSpaceCouponsListTest extends TestCase
     {
         $dto = new GetAdSpaceCouponsList(
             3,
-            campaign: 3,
-            category: [1],
+            campaign: [3],
+            category: 1,
             campaignCategory: 89,
             type: 14,
             search: 'search-string',
@@ -31,8 +31,8 @@ class GetAdSpaceCouponsListTest extends TestCase
         $this->assertSame("GET", $dto->getHttpMethod());
         $this->assertEmpty($dto->getBody());
         $this->assertSame([
-            'campaign' => 3,
-            'category' => [1],
+            'campaign' => [3],
+            'category' => 1,
             'campaignCategory' => 89,
             'type' => 14,
             'search' => 'search-string',


### PR DESCRIPTION
- Change `campaign` parameter from `?int` to `?array` in `GetAdSpaceCouponsList.php`
- Change `category` parameter from `?array` to `?int` in `GetAdSpaceCouponsList.php`
- Update `GetAdSpaceCouponsListTest.php` to reflect the changes in parameter types
- Ensure tests correctly handle the updated parameter types in assertions